### PR TITLE
fix: 修复jest config不建议使用的警告

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   verbose: true,
   "globals": {
     "ts-jest": {
-      "tsConfigFile": "tsconfig.jest.json"
+      "tsConfig": "tsconfig.jest.json"
     }
   },
   "moduleNameMapper": {


### PR DESCRIPTION
[WARNING]
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfigFile" is deprecated, use "[jest-config].globals.ts-jest.tsConfig" instead.