### PR TITLE
fix: monitor cos with http

### DIFF
--- a/pkg/resource.go
+++ b/pkg/resource.go
@@ -25,10 +25,10 @@ func newResourceHandler(ds *cloudMonitorDatasource) backend.CallResourceHandler 
 func (ds *cloudMonitorDatasource) CosApi(rw http.ResponseWriter, req *http.Request) {
 	regions := req.URL.Query()["region"]
 
-	baseURL := "https://service.cos.myqcloud.com"
+	baseURL := "http://service.cos.myqcloud.com"
 	if len(regions) > 0 {
 		// cos.<Region>.myqcloud.com
-		baseURL = fmt.Sprintf("https://cos.%s.myqcloud.com", regions[0])
+		baseURL = fmt.Sprintf("http://cos.%s.myqcloud.com", regions[0])
 	}
 
 	su, _ := url.Parse(baseURL)


### PR DESCRIPTION
云原生监控通过 ip 访问云监控，
当前cos https 的ca证书未签发 ip 地址，
因此 云原生监控 无法监控cos相关资源

为了兼容上述场景，将 cos 的访问协议从 `https` 改为 `http`